### PR TITLE
feat: navbar 컴포넌트 생성 및 라우팅 기능 작업

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import "./globals.css";
 import NavBar from "@/components/NavBar";
+import "./global.css";
 
 const inter = Inter({ subsets: ["latin"] });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import NavBar from "@/components/NavBar";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,7 +17,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.className} w-[375px] h-full`}>
+        {children}
+        <NavBar />
+      </body>
     </html>
   );
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,18 @@
+import NavMenu from "./NavMenu";
+import { ITEMS } from "@/lib/constants/navMenuItems";
+
+const NavBar = () => {
+  return (
+    <nav className="bg-red-500 w-full h-20">
+      <ul className="h-full flex justify-around items-center">
+        {ITEMS.map((item) => (
+          <NavMenu key={item.ko} path={item.path}>
+            {item.ko}
+          </NavMenu>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default NavBar;

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+
+const NavMenu = ({ children, path }: { children: ReactNode; path: string }) => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(path);
+  };
+
+  return (
+    <li onClick={handleClick}>
+      <button>{children}</button>
+    </li>
+  );
+};
+
+export default NavMenu;

--- a/src/lib/constants/navMenuItems.ts
+++ b/src/lib/constants/navMenuItems.ts
@@ -1,0 +1,5 @@
+export const ITEMS = [
+  { en: "Home", ko: "홈", path: "/" },
+  { en: "mail", ko: "우편함", path: "/mail" },
+  { en: "data", ko: "자료", path: "/data" },
+];


### PR DESCRIPTION
## 연관된 이슈
close #3 

## 작업 내용
NavBar 컴포넌트 재사용성 용이하게 작업 (상수로 navbar 메뉴 아이템 목록 관리 > 추가할 navbar 메뉴 있으면 상수에 추가)
상수로 관리 중인 메뉴 아이템 내용 (en 메뉴 영어 이름, ko 메뉴 한글 이름, path 메뉴 클릭 시 이동할 라우팅 경로)

## 스크린샷 (선택)

## 리뷰 요구사항(선택)
navbar 메뉴를 재사용성을 고려해서 구성했는데 이 방식에 대한 피드백 부탁드립니다. (이 방법 말고 다른 방법이 더 낫지 않은지? 아니면 추가로 더 고려해야할 부분이 있는지?)
